### PR TITLE
Make `Span::inactive()` a const fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rustracing"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Takeru Ohta <phjgt308@gmail.com>", "Cloudflare Inc."]
 description = "OpenTracing API for Rust"
 homepage = "https://github.com/cloudflare/rustracing"

--- a/src/span.rs
+++ b/src/span.rs
@@ -70,7 +70,7 @@ impl<T> Span<T> {
     /// let span = Span::<()>::inactive();
     /// assert!(! span.is_sampled());
     /// ```
-    pub fn inactive() -> Self {
+    pub const fn inactive() -> Self {
         Span(None)
     }
 


### PR DESCRIPTION
By allowing this function to be called in const contexts, applications can store a single inactive span as a sentinel in a `static`.