### PR TITLE
Allow generic span consumer implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rustracing"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>", "Cloudflare Inc."]
 description = "OpenTracing API for Rust"
 homepage = "https://github.com/cloudflare/rustracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = [ "stacktrace" ]
 [dependencies]
 backtrace = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["sync"] }
-rand = "0.8.1"
+rand = "0.10"
 trackable = "1.2"
 
 [dev-dependencies]

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,7 +1,6 @@
 //! `Sampler` trait and its built-in implementations.
 use crate::span::CandidateSpan;
 use crate::{ErrorKind, Result};
-use rand::{self, Rng};
 use std::fmt::Debug;
 
 /// `Sampler` decides whether a new trace should be sampled or not.
@@ -70,7 +69,7 @@ impl ProbabilisticSampler {
 }
 impl<T> Sampler<T> for ProbabilisticSampler {
     fn is_sampled(&self, _span: &CandidateSpan<T>) -> bool {
-        rand::thread_rng().gen_range(0.0..1.0) < self.sampling_rate
+        rand::random_range(0.0..1.0) < self.sampling_rate
     }
 }
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -12,10 +12,65 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 
-/// Finished span receiver.
+/// Generic interface to receive [`FinishedSpan`]s from rustracing.
+pub trait SpanConsumer<T>: Send + Sync {
+    /// Consumes a [`FinishedSpan`] when the application closes a span.
+    ///
+    /// This should not block the caller for any significant amount of time.
+    /// It is better to drop spans if the consumer is overloaded.
+    fn consume_span(&self, span: FinishedSpan<T>);
+}
+
+impl<T: Send> SpanConsumer<T> for mpsc::UnboundedSender<FinishedSpan<T>> {
+    fn consume_span(&self, span: FinishedSpan<T>) {
+        let _ = self.send(span);
+    }
+}
+
+impl<T: Send> SpanConsumer<T> for mpsc::Sender<FinishedSpan<T>> {
+    fn consume_span(&self, span: FinishedSpan<T>) {
+        let _ = self.try_send(span);
+    }
+}
+
+impl<T: Send> SpanConsumer<T> for std::sync::mpsc::Sender<FinishedSpan<T>> {
+    fn consume_span(&self, span: FinishedSpan<T>) {
+        let _ = self.send(span);
+    }
+}
+
+impl<T: Send> SpanConsumer<T> for std::sync::mpsc::SyncSender<FinishedSpan<T>> {
+    fn consume_span(&self, span: FinishedSpan<T>) {
+        let _ = self.try_send(span);
+    }
+}
+
+/// Unbounded [`tokio::sync::mpsc`] receiver for finished spans.
 pub type SpanReceiver<T> = mpsc::UnboundedReceiver<FinishedSpan<T>>;
-/// Sender of finished spans to the destination channel.
+/// Deprecated: alias for default [`SpanConsumer`] implementation.
+#[deprecated = "SpanSender is an implementation detail of rustracing. It should not be public."]
 pub type SpanSender<T> = mpsc::UnboundedSender<FinishedSpan<T>>;
+
+/// An `Arc<dyn SpanConsumer>` wrapper to implement `Debug` on.
+pub(crate) struct SharedSpanConsumer<T>(Arc<dyn SpanConsumer<T>>);
+
+impl<T> SharedSpanConsumer<T> {
+    pub(crate) fn new(consumer: impl SpanConsumer<T> + 'static) -> Self {
+        Self(Arc::new(consumer))
+    }
+}
+
+impl<T> fmt::Debug for SharedSpanConsumer<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("SharedSpanConsumer")
+    }
+}
+
+impl<T> Clone for SharedSpanConsumer<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
 
 /// Callback to execute before a [`Span`] is finalized.
 pub struct FinishSpanCallback<T>(FinishCallbackInner<T>);
@@ -284,7 +339,7 @@ impl<T> Drop for Span<T> {
                 logs: inner.logs,
                 context: inner.context,
             };
-            let _ = inner.span_tx.send(finished);
+            inner.span_tx.0.consume_span(finished);
         }
     }
 }
@@ -304,7 +359,7 @@ struct SpanInner<T> {
     logs: Vec<Log>,
     context: SpanContext<T>,
     finish_cb: Option<FinishSpanCallback<T>>,
-    span_tx: SpanSender<T>,
+    span_tx: SharedSpanConsumer<T>,
 }
 
 /// Finished span.
@@ -546,7 +601,7 @@ pub struct StartSpanOptions<'a, S: 'a, T: 'a> {
     references: Vec<SpanReference<T>>,
     baggage_items: Vec<BaggageItem>,
     finish_cb: Option<FinishSpanCallback<T>>,
-    span_tx: &'a SpanSender<T>,
+    span_tx: &'a SharedSpanConsumer<T>,
     sampler: &'a S,
 }
 impl<'a, S: 'a, T: 'a> StartSpanOptions<'a, S, T>
@@ -626,7 +681,11 @@ where
         Span::new(state, self)
     }
 
-    pub(crate) fn new<N>(operation_name: N, span_tx: &'a SpanSender<T>, sampler: &'a S) -> Self
+    pub(crate) fn new<N>(
+        operation_name: N,
+        span_tx: &'a SharedSpanConsumer<T>,
+        sampler: &'a S,
+    ) -> Self
     where
         N: Into<Cow<'static, str>>,
     {
@@ -676,7 +735,7 @@ where
 
 /// Immutable handle of `Span`.
 #[derive(Debug, Clone)]
-pub struct SpanHandle<T>(Option<(SpanContext<T>, SpanSender<T>)>);
+pub struct SpanHandle<T>(Option<(SpanContext<T>, SharedSpanConsumer<T>)>);
 impl<T> SpanHandle<T> {
     /// Returns `true` if this span is sampled (i.e., being traced).
     pub fn is_sampled(&self) -> bool {

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,5 +1,5 @@
 use crate::sampler::Sampler;
-use crate::span::{SpanReceiver, SpanSender, StartSpanOptions};
+use crate::span::{SharedSpanConsumer, SpanConsumer, SpanReceiver, StartSpanOptions};
 use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -25,20 +25,22 @@ use tokio::sync::mpsc;
 #[derive(Debug)]
 pub struct Tracer<S, T> {
     sampler: Arc<S>,
-    span_tx: SpanSender<T>,
+    span_tx: SharedSpanConsumer<T>,
 }
-impl<S: Sampler<T>, T> Tracer<S, T> {
-    /// Makes a new `Tracer` instance.
+impl<S: Sampler<T>, T: Send + 'static> Tracer<S, T> {
+    /// Makes a new `Tracer` instance with an unbounded [`tokio::sync::mpsc`] channel.
     pub fn new(sampler: S) -> (Self, SpanReceiver<T>) {
         let (span_tx, span_rx) = mpsc::unbounded_channel();
-
-        (
-            Tracer {
-                sampler: Arc::new(sampler),
-                span_tx,
-            },
-            span_rx,
-        )
+        (Self::with_consumer(sampler, span_tx), span_rx)
+    }
+}
+impl<S: Sampler<T>, T> Tracer<S, T> {
+    /// Makes a new `Tracer` instance with a custom consumer implementation.
+    pub fn with_consumer<C: SpanConsumer<T> + 'static>(sampler: S, consumer: C) -> Self {
+        Self {
+            sampler: Arc::new(sampler),
+            span_tx: SharedSpanConsumer::new(consumer),
+        }
     }
 
     /// Returns `StartSpanOptions` for starting a span which has the name `operation_name`.


### PR DESCRIPTION
rustracing previously forced users to consume finished spans via a tokio
mpsc channel. In some cases a different type of consumer is required
(such as a multi-consumer queue), so we want to make this part of
rustracing generic.

This adds a dynamic dispatch to each `Span::drop` call, but it should be
easy to predict since generally there is only a single `Tracer` per
application. Adding a span into a queue for consumption is also
typically much higher overhead than a dynamic dispatch.

The change is intended to be backwards compatible, but adds a new trait
bound to `Tracer`: `T` must be `Send + 'static`. In theory a
single-threaded application would not have required this before, but in
practice every implementation should fulfill these bounds.

Includes a release commit for `cf-rustracing 1.3.0`