### PR TITLE
chore: Release cf-rustracing version 1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-rustracing"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>", "Cloudflare Inc."]
 description = "OpenTracing API for Rust"
 homepage = "https://github.com/cloudflare/rustracing"


### PR DESCRIPTION
### Added
- `trait RoutingMetadata` allows specifying routing information for each span separately from the span's exported data. `SpanConsumer` implementations can read this information and distribute spans to destinations based on a `group_key()` and metadata that is encoded on the OTLP HTTP request. (#11)